### PR TITLE
Mod nbout to work in the device menu

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -11,14 +11,14 @@ function my_midi:send(data) end
 function my_midi:note_on(note, vel, ch)
     if ch == 1 then
         if not channel_is_set_up then
-            print("Refusing to access nbout_chan_1")
+            print("nbout received note_on before initialization")
             return
         end
         local p = params:lookup_param("nbout_chan_1"):get_player()
         -- some sequencers (e.g. jala) seem to send nil for vel.
         -- assume they want a default velocity
         if vel == nil then
-            vel = 127
+            vel = 80
         end
         p:note_on(note, vel/127)
     end
@@ -26,7 +26,7 @@ end
 function my_midi:note_off(note, vel, ch)
     if ch == 1 then
         if not channel_is_set_up then
-            print("Refusing to access nbout_chan_1")
+            print("nbout received note_on before initialization")
             return
         end
         local p = params:lookup_param("nbout_chan_1"):get_player()
@@ -39,7 +39,7 @@ end
 function my_midi:cc(cc, val, ch)
     if ch == 1 and cc == 72 then
         if not channel_is_set_up then
-            print("Refusing to access nbout_chan_1")
+            print("nbout received note_on before initialization")
             return
         end
         local p = params:lookup_param("nbout_chan_1"):get_player()
@@ -113,12 +113,10 @@ mod.hook.register("script_pre_init", "nbout pre init", function()
         nb:add_param("nbout_chan_1", "nb midi ch 1")
         nb:add_player_params()
         channel_is_set_up = true
-        print("nbout_chan_1 is set up")
     end
 end)
 
 mod.hook.register("script_post_cleanup", "nbout post cleanup", function()
     channel_is_set_up = false
-    print("nbout_chan_1 is disabled")
     midi = fake_midi.real_midi
 end)

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -1,6 +1,7 @@
 local mod = require 'core/mods'
 local nb = require('nbout/lib/nb/lib/nb')
 
+local channel_is_set_up = false
 
 local my_midi = {
     name="nb",
@@ -9,12 +10,25 @@ local my_midi = {
 function my_midi:send(data) end
 function my_midi:note_on(note, vel, ch)
     if ch == 1 then
+        if not channel_is_set_up then
+            print("Refusing to access nbout_chan_1")
+            return
+        end
         local p = params:lookup_param("nbout_chan_1"):get_player()
+        -- some sequencers (e.g. jala) seem to send nil for vel.
+        -- assume they want a default velocity
+        if vel == nil then
+            vel = 127
+        end
         p:note_on(note, vel/127)
     end
 end
 function my_midi:note_off(note, vel, ch)
     if ch == 1 then
+        if not channel_is_set_up then
+            print("Refusing to access nbout_chan_1")
+            return
+        end
         local p = params:lookup_param("nbout_chan_1"):get_player()
         p:note_off(note)
     end
@@ -24,6 +38,10 @@ function my_midi:pitchbend(val, ch)
 end
 function my_midi:cc(cc, val, ch)
     if ch == 1 and cc == 72 then
+        if not channel_is_set_up then
+            print("Refusing to access nbout_chan_1")
+            return
+        end
         local p = params:lookup_param("nbout_chan_1"):get_player()
         p:modulate(val/127)
     end
@@ -70,6 +88,10 @@ meta_fake_midi.__index = function(t, key)
                 idx = 1
             end
             if idx <= 16 then
+                if t.real_midi.vports[idx].name == "nb" then
+                  print("Connecting to nbout")
+                  return my_midi
+                end
                 return t.real_midi.connect(idx)
             end
             if idx == #t.real_midi.vports + 1 then
@@ -90,9 +112,13 @@ mod.hook.register("script_pre_init", "nbout pre init", function()
         params:add_separator("nbout")
         nb:add_param("nbout_chan_1", "nb midi ch 1")
         nb:add_player_params()
+        channel_is_set_up = true
+        print("nbout_chan_1 is set up")
     end
 end)
 
 mod.hook.register("script_post_cleanup", "nbout post cleanup", function()
+    channel_is_set_up = false
+    print("nbout_chan_1 is disabled")
     midi = fake_midi.real_midi
 end)


### PR DESCRIPTION
This is very much a hack, and feel free to take it as a suggestion/research product instead of an actual PR if you like.

This PR allows most norns sequencers to use nbout, including sequencers that do not allow choice of midi device (always device 1) and sequencers that set up their midi device options or initialize the midi device before nbout is initialized.

The basic idea is to return `my_midi` when the device at the requested vport index is named "nb".  (A more secure method should be found.)  The midi channel parameter is also protected from access when it is not yet set up.

Still a lot of work to be done I'm sure.

Tested with the sequencers listed below.  (Successful unless otherwise noted.)

- awake
- awake passersby
- awake rings
- bouys
- constellations
- deliquencer
- descartes
- dreamsequence
- fall
- flora
- fugu
- fugarc [no midi out support?]
- get in the sea
- initenere
- krill
- laminations
- less concepts [init fail first time, then init succeeds on retry]
- less concepts 3
- l_ll__l_ [fail: output on hardware but no output on nb]
- loom
- nmmelodymagic
- o-o-o
- orca
- quence [fail: output on hardware but no output on nb]
- sempra
- skyines [no midi out support?]
- streams
- takt [too many parameters, can't scroll down to turn on nb!]
- tambla [can't figure out how to make sound]
- tidbit
- traffic
- washi
- jala
- meadowphysics
- metrix
- mouse
- tviburar
- zellen
- arcologies
